### PR TITLE
fix: Remove some warning

### DIFF
--- a/src/actions/add.rs
+++ b/src/actions/add.rs
@@ -5,9 +5,9 @@ use std::io::StdinLock;
 impl HrtorProcessor {
     pub(crate) fn add(&self) -> CommandStatus {
         let reader: StdinLock = std::io::stdin().lock();
-        let writer: std::io::Stdout = std::io::stdout();
+        let _writer: std::io::Stdout = std::io::stdout();
 
-        let new_context = push_context(reader, writer);
+        let new_context = push_context(reader, _writer);
         {
             self.editing_file.lock().unwrap().context = new_context;
         }
@@ -49,7 +49,7 @@ mod tests {
 
     #[test]
     fn test_push_context() {
-        let mut writer: Vec<u8> = Vec::new();
+        let writer: Vec<u8> = Vec::new();
         let reader = std::io::Cursor::new(b"test\ntest\ntest\n.\n");
         let result = push_context(reader, writer);
         assert_eq!(result, "test\ntest\ntest\n");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,6 +120,6 @@ mod test {
                 context: "test".to_string(),
             })),
         };
-        let hrtor = Hrtor::new(hrtor_processor);
+        let _hrtor = Hrtor::new(hrtor_processor);
     }
 }


### PR DESCRIPTION
# Reproducibility
1804e50efaed0ea3e782ca5eec6eb15108b199a4
Run `cargo test`, then:
```txt
   Compiling hrtor v0.1.0 (/home/haruki/program-dir/hrtor)
warning: variable does not need to be mutable
  --> src/actions/add.rs:52:13
   |
52 |         let mut writer: Vec<u8> = Vec::new();
   |             ----^^^^^^
   |             |
   |             help: remove this `mut`
   |
   = note: `#[warn(unused_mut)]` on by default

warning: unused variable: `hrtor`
   --> src/lib.rs:123:13
    |
123 |         let hrtor = Hrtor::new(hrtor_processor);
    |             ^^^^^ help: if this is intentional, prefix it with an underscore: `_hrtor`
    |
    = note: `#[warn(unused_variables)]` on by default

warning: `hrtor` (lib test) generated 2 warnings (run `cargo fix --lib -p hrtor --tests` to apply 2 suggestions)
    Finished test [unoptimized + debuginfo] target(s) in 0.56s
     Running unittests src/lib.rs (target/debug/deps/hrtor-77178c237ca2e8d0)

running 4 tests
test file_loader::test::test_get_config_info ... ok
test actions::add::tests::test_push_context ... ok
test file_loader::test::test_get_file_info ... ok
test test::test_handle_command ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests src/bin/hrtor.rs (target/debug/deps/hrtor-7ea1271f49b48cfe)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests hrtor

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```