### PR TITLE
fix(Cargo.toml): Edit deps' version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,10 @@ categories = ["text-editors"]
 clap = { version = "4.4.7", features = ["derive"] }
 linefeed = "0.6.0"
 rlua = "0.19.7"
-file_loader = { path = "file_loader" }
-cli = { path = "cli" }
-constants = { path = "constants" }
-processor = { path = "processor" }
+file_loader = { path = "file_loader", version = "0.1.0" }
+cli = { path = "cli", version = "0.1.0" }
+constants = { path = "constants", version = "0.1.0" }
+processor = { path = "processor", version = "0.1.0" }
 
 [workspace]
 


### PR DESCRIPTION
# Why did you create this PullRequest?
- v0.2.0のタグを切ったが`crates.io`にリリースできなかったため。

# Changes
- `/Cargo.toml`